### PR TITLE
Changing the master/slave terminology

### DIFF
--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -162,10 +162,10 @@ func (db *wiredDB) CheckConnectivity() error {
 }
 
 // SyncDBAsync is like SyncDB except it also takes a result channel where the
-// caller should wait to receive the result. When a slave BlockGetter is in use,
-// fetchToHeight is used to indicate at what height the MasterBlockGetter will
+// caller should wait to receive the result. When a subordinate BlockGetter is in use,
+// fetchToHeight is used to indicate at what height the MainBlockGetter will
 // start sending blocks for processing. e.g. When an auxiliary DB owns the
-// MasterBlockGetter, fetchToHeight should be one past the best block in the aux
+// MainBlockGetter, fetchToHeight should be one past the best block in the aux
 // DB, thus putting wiredDB sync into "catch up" mode where it just pulls blocks
 // from RPC until it matches the auxDB height and coordination begins.
 func (db *wiredDB) SyncDBAsync(ctx context.Context, res chan dbtypes.SyncResult, blockGetter rpcutils.BlockGetter, fetchToHeight int64,

--- a/main.go
+++ b/main.go
@@ -566,7 +566,7 @@ func _main(ctx context.Context) error {
 			latestBlockHash, barLoad)
 
 		// Now that stakedb is either catching up or waiting for a block, start
-		// the auxDB sync, which is the master block getter, retrieving and
+		// the auxDB sync, which is the main block getter, retrieving and
 		// making available blocks to the baseDB. In return, baseDB maintains a
 		// StakeDatabase at the best block's height. For a detailed description
 		// on how the DBs' synchronization is coordinated, see the documents in


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.